### PR TITLE
Ambient light improvements

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8184,9 +8184,8 @@ child will follow movement and rotation of that bone.
 * `set_lighting(light_definition)`: sets lighting for the player
     * Passing no arguments resets lighting to its default values.
     * `light_definition` is a table with the following optional fields:
-      * `ambient_light` is a table controlling amount and color of ambient light (global lighting)
-        * `luminance` sets the amount of ambient light in range (0... LIGHT_SUN) like `light_source` has (default: `0`)
-        * `color` sets the color of ambient light (ColorSpec) (default: `{a = 255, r = 255, g = 255, b = 255}`). Alpha is ignored.
+      * `ambient_light` is a ColorSpec controlling lightness & color of ambient light; alpha must be 255
+        (global lighting; default: `{a = 255, r = 0, g = 0, b = 0}` / last set value).
       * `saturation` sets the saturation (vividness; default: `1.0`).
         * values > 1 increase the saturation
         * values in [0,1] decrease the saturation

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -298,9 +298,7 @@ void ClientEnvironment::step(float dtime)
 		m_script->environment_step(dtime);
 
 	// Update the ambient light
-	AmbientLight &ambient_light = getLocalPlayer()->getLighting().ambient_light;
-
-	video::SColor new_ambient_light_clr = encodeAmbientLight(ambient_light.luminance, ambient_light.color);
+	auto new_ambient_light_clr = getLocalPlayer()->getLighting().ambient_light;
 
 	if (new_ambient_light_clr != m_ambient_light) {
 		getClientMap().forceUpdateLightColor();

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -163,5 +163,6 @@ private:
 	u64 m_frame_time = 0;
 	u64 m_frame_dtime = 0;
 	u64 m_frame_time_pause_accumulator = 0;
-	video::SColor m_ambient_light {0, 0, 0, 0};
+	// Note: Alpha should always be 255.
+	video::SColor m_ambient_light {255, 0, 0, 0};
 };

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -719,7 +719,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	const float animation_time = m_client->getAnimationTime();
 	const int crack = m_client->getCrackLevel();
 	const u32 daynight_ratio = m_client->getEnv().getDayNightRatio();
-	const video::SColor &ambient_light = m_client->getEnv().getAmbientLight();
+	const auto ambient_light = m_client->getEnv().getAmbientLight();
 
 	const v3f camera_position = m_camera_position;
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1030,19 +1030,6 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	return video::SColor(r, b, b, b);
 }
 
-video::SColor encodeAmbientLight(u8 light, video::SColor color)
-{
-	video::SColor res_color(0, 0, 0, 0);
-
-	float light_f = light / 15.f;
-
-	res_color.setRed(core::round32(light_f * color.getRed()));
-	res_color.setGreen(core::round32(light_f * color.getGreen()));
-	res_color.setBlue(core::round32(light_f * color.getBlue()));
-
-	return res_color;
-}
-
 u8 get_solid_sides(MeshMakeData *data)
 {
 	std::unordered_map<v3s16, u8> results;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -297,8 +297,6 @@ private:
  */
 video::SColor encode_light(u16 light, u8 emissive_light);
 
-video::SColor encodeAmbientLight(u8 light, video::SColor color);
-
 // Compute light at node
 u16 getInteriorLight(MapNode n, s32 increment, const NodeDefManager *ndef);
 u16 getFaceLight(MapNode n, MapNode n2, const NodeDefManager *ndef);

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -47,26 +47,11 @@ struct AutoExposure
 	AutoExposure();
 };
 
-/*
- * Parameters for adjusting ambient light affecting on colors of map nodes and entities
- */
-struct AmbientLight
-{
-	AmbientLight() : luminance(0), color(255, 255, 255, 255)
-	{}
-	/// @brief Minimal threshold of luminance of ambience. Can be from 0 - 14.
-	u8 luminance;
-
-	/// @brief Color of ambient light. Default is white color.
-	video::SColor color;
-};
-
-/** Describes ambient light settings for a player
- */
 struct Lighting
 {
 	AutoExposure exposure;
-	AmbientLight ambient_light;
+	/// @brief Ambient light color & intensity for nodes & entities. Alpha is ignored.
+	video::SColor ambient_light = {255, 0, 0, 0};
 	float shadow_intensity {0.0f};
 	float saturation {1.0f};
 	float volumetric_light_strength {0.0f};

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1802,22 +1802,29 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
 
-	if (pkt->getRemainingBytes() >= 4)
-		*pkt >> lighting.shadow_intensity;
-	if (pkt->getRemainingBytes() >= 4)
-		*pkt >> lighting.saturation;
-	if (pkt->getRemainingBytes() >= 24) {
-		*pkt >> lighting.exposure.luminance_min
-				>> lighting.exposure.luminance_max
-				>> lighting.exposure.exposure_correction
-				>> lighting.exposure.speed_dark_bright
-				>> lighting.exposure.speed_bright_dark
-				>> lighting.exposure.center_weight_power;
-	}
-	if (pkt->getRemainingBytes() >= 4)
-		*pkt >> lighting.volumetric_light_strength;
-	if (pkt->getRemainingBytes() >= 1) {
-		*pkt >> lighting.ambient_light.luminance
-				>> lighting.ambient_light.color;
-	}
+	if (pkt->getRemainingBytes() < 4)
+		return;
+	*pkt >> lighting.shadow_intensity;
+
+	if (pkt->getRemainingBytes() < 4)
+		return;
+	*pkt >> lighting.saturation;
+
+	if (pkt->getRemainingBytes() < 24)
+		return;
+	*pkt >> lighting.exposure.luminance_min
+			>> lighting.exposure.luminance_max
+			>> lighting.exposure.exposure_correction
+			>> lighting.exposure.speed_dark_bright
+			>> lighting.exposure.speed_bright_dark
+			>> lighting.exposure.center_weight_power;
+
+	if (pkt->getRemainingBytes() < 4)
+		return;
+	*pkt >> lighting.volumetric_light_strength;
+
+	if (pkt->getRemainingBytes() < 4)
+		return;
+	*pkt >> lighting.ambient_light;
+	lighting.ambient_light.setAlpha(255); // alpha should always be 255
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_object.h"
 #include <cmath>
+#include "common/c_types.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_inventory.h"
 #include "lua_api/l_item.h"
@@ -2528,14 +2529,10 @@ int ObjectRef::l_set_lighting(lua_State *L)
 		lua_pop(L, 1); // shadows
 
 		lua_getfield(L, 2, "ambient_light");
-		if(lua_istable(L, -1)) {
-			getintfield(L, -1, "luminance", lighting.ambient_light.luminance);
-			lighting.ambient_light.luminance = rangelim(lighting.ambient_light.luminance, 0, LIGHT_SUN);
-
-			lua_getfield(L, -1, "color");
-			if (!lua_isnil(L, -1))
-				read_color(L, -1, &lighting.ambient_light.color);
-			lua_pop(L, 1);
+		if (!lua_isnil(L, -1)) {
+			read_color(L, -1, &lighting.ambient_light);
+			if (lighting.ambient_light.getAlpha() != 255)
+				throw LuaError("ambient light alpha must be 255");
 		}
 		lua_pop(L, 1); // ambient light
 
@@ -2558,7 +2555,7 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			lighting.volumetric_light_strength = rangelim(lighting.volumetric_light_strength, 0.0f, 1.0f);
 		}
 		lua_pop(L, 1); // volumetric_light
-}
+	}
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1881,8 +1881,7 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.volumetric_light_strength;
 
-	pkt << lighting.ambient_light.luminance
-			<< lighting.ambient_light.color;
+	pkt << lighting.ambient_light;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
* Remove redundant luminance. This makes it both more straightforward for modders and the engine.
* Ensure that unused ambient light alpha is always 255. (It might be cleaner to use a `std::array<u8, 3>` instead. It would be cleanest to have a RGB color class in Irrlicht, but ain't nobody got time for that.)
* I've also "fixed" the set lighting packet reading to use early returns to avoid some theoretical shenanigans (and checked for the proper amount of bytes).